### PR TITLE
part移動時、背景スクロールをリセットするように

### DIFF
--- a/Assets/setsuna/Program/GameScene/Scripts/Camera/SetsunaPlayerCamera.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Camera/SetsunaPlayerCamera.cs
@@ -89,7 +89,7 @@ public class SetsunaPlayerCamera : SetsunaSlashScript
         }
     }
 
-    void SetPos()
+    public void SetPos()
     {
         if (hub.currentPart == null) return;
 

--- a/Assets/setsuna/Program/GameScene/Scripts/Game_HubScript.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Game_HubScript.cs
@@ -36,6 +36,9 @@ public class Game_HubScript : SetsunaSlashScript
 
     public void SetPart(StagePart stage)
     {
+        currentPart = stage;
+        camera_.SetPos();
+
         playingStage.SetCurrentPart(playingStage.stageParts.FindIndex((n) => (n == stage.gameObject)));
 
         if (bgmAS.clip != stage.bgm)
@@ -46,8 +49,6 @@ public class Game_HubScript : SetsunaSlashScript
             else bgmAS.Stop();
         }
         Camera.main.backgroundColor = stage.backGroundColor;
-
-        currentPart = stage;
     }
 
     public Vector2 CameraPosClamp(Vector2 pos, Camera camera)

--- a/Assets/setsuna/Program/GameScene/Scripts/Stage/StageManager.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Stage/StageManager.cs
@@ -243,7 +243,7 @@ public class StageManager : SetsunaSlashScript
 
     public void SetBackGround(StagePart next)
     {
-        if ((currentBG != null) && (currentBG == next.backGroundGroup)) return;
+        //if ((currentBG != null) && (currentBG == next.backGroundGroup)) return;
 
         Camera.main.GetComponent<Camera>().backgroundColor = next.backGroundColor;
 


### PR DESCRIPTION
part間で移動時、背景マテリアルのスクロールをリセットする仕様を追加。
スクロール位置は該当partの初めのセーブポイントを基準に決定。