### PR TITLE
斬撃カウント消費周りの仕様変更と修正

### DIFF
--- a/Assets/setsuna/Program/GameScene/Scripts/Enemy/Golem/Golem_Punch.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Enemy/Golem/Golem_Punch.cs
@@ -19,6 +19,6 @@ public class Golem_Punch : SetsunaSlashScript
 
         var status = col.GetComponentInParent<PL_Status>();
 
-        status.ConsumeCount();
+        status.Damage();
     }
 }

--- a/Assets/setsuna/Program/GameScene/Scripts/Enemy/birds/Bird_strike.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Enemy/birds/Bird_strike.cs
@@ -45,7 +45,7 @@ public class Bird_strike : SetsunaSlashScript
         if (col.gameObject.layer == playerLayer && !hasDamaged)
         {
             hasDamaged = true;
-            hub.PL_Ctrler.stat.ConsumeCount();
+            hub.PL_Ctrler.stat.Damage();
         }
         else if(col.gameObject.layer is slashableLayer or not_slashableLayer)
         {

--- a/Assets/setsuna/Program/GameScene/Scripts/Gimmick/Rock.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Gimmick/Rock.cs
@@ -39,7 +39,7 @@ public class Rock : SetsunaSlashScript
         float dt = 0, scale = transform.localScale.x;
         while (dt <= appearTime)
         {
-            transform.Rotate(Vector3.forward * appearRotationCount * 360 * Time.deltaTime);
+            transform.Rotate(360 * appearRotationCount * Time.deltaTime * Vector3.forward);
             transform.localScale = Vector2.one * (scale * (dt / appearTime));
 
             dt += Time.deltaTime;
@@ -63,7 +63,7 @@ public class Rock : SetsunaSlashScript
         {
             if (rb.velocity.magnitude < damageSpeed) return;
 
-            col.gameObject.GetComponentInParent<PL_Status>().ConsumeCount();
+            col.gameObject.GetComponentInParent<PL_Status>().Damage();
         }
         else if (col.collider.GetComponent<Rock>())
         {

--- a/Assets/setsuna/Program/GameScene/Scripts/Gimmick/RockStinger.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Gimmick/RockStinger.cs
@@ -151,7 +151,7 @@ public class RockStinger : SetsunaSlashScript
         if (damaged) return;
 
         var state = col.gameObject.GetComponentInParent<PL_Status>();
-        state.ConsumeCount();
+        state.Damage();
         damaged = true;
     }
 

--- a/Assets/setsuna/Program/GameScene/Scripts/Player/PL_Attack.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Player/PL_Attack.cs
@@ -315,12 +315,11 @@ public class PL_Attack : SetsunaSlashScript
 
     void ChargeSlash(Vector2 start, Vector2 end)
     {
-        if (!config.easyMode && !pl.Status.inAnotherPart){
-            var result = pl.Status.ConsumeCount();
-            if (!result){
-                Attack();
-                return;
-            }
+        var result = pl.Status.TryConsumeCount();
+        if (!result)
+        {
+            Attack();
+            return;
         }
 
         var effect = Instantiate(slashEffectPrefab);

--- a/Assets/setsuna/Program/GameScene/Scripts/Player/PL_Status.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Player/PL_Status.cs
@@ -4,13 +4,17 @@ using UnityEngine;
 
 public class PL_Status:SetsunaSlashScript
 {
+    [SerializeField] PartStat partStat;
     [SerializeField] int recommendCount, currentCount, currentScoreAdditional;
     [SerializeField] int hintUsed;
     [SerializeField] bool inPuzzle;
-    public bool inAnotherPart;
+    public bool InAnotherPart { get => partStat == PartStat.another; }
+    public bool IsGoaled { get => partStat == PartStat.goaled; }
 
     Player pl;
     SlashCountUI ui;
+
+    public enum PartStat { common, goaled, another }
 
     void Start()
     {
@@ -26,12 +30,15 @@ public class PL_Status:SetsunaSlashScript
         }
     }
 
+    public void Damage() => TryConsumeCount();
     /// <summary>
     /// aŒ‚‰ñ”‚ğÁ”ï‚·‚é
     /// </summary>
     /// <returns>Á”ï‚É¬Œ÷‚µ‚½‚©‚Ç‚¤‚©(0‚ğ‰º‰ñ‚ê‚È‚¢)</returns>
-    public bool ConsumeCount()
+    public bool TryConsumeCount()
     {
+        if(partStat != PartStat.common || config.easyMode) return true;
+
         if(currentCount + currentScoreAdditional <= 0) return false;
         else if (currentCount > 0)
         {
@@ -51,7 +58,7 @@ public class PL_Status:SetsunaSlashScript
     /// ƒqƒ“ƒg‚ğg‚¤
     /// </summary>
     /// <returns>•]‰¿“_‚ª‘«‚è‚È‚¢‚Æfalse‚ğ•Ô‚·</returns>
-    public bool UseHint()
+    public bool TryUseHint()
     {
         if (currentScoreAdditional <= 0) return false;
         else
@@ -65,14 +72,20 @@ public class PL_Status:SetsunaSlashScript
 
     public void SetAnotherPart()
     {
-        inAnotherPart = true;
-        ui.SetAnotherRoom();
+        partStat = PartStat.another;
+        ui.SetInfinity(true);
+    }
+
+    public void SetGoaled()
+    {
+        partStat = PartStat.goaled;
+        ui.SetInfinity(false);
     }
 
     public void SetRecommendCount(int max)
     {
         inPuzzle = (max >= 0);
-        inAnotherPart = false;
+        partStat = PartStat.common;
 
         this.recommendCount = max;
         currentCount = max;
@@ -82,7 +95,7 @@ public class PL_Status:SetsunaSlashScript
     }
     public void ResetCount()
     {
-        if (inAnotherPart) return;
+        if (partStat != PartStat.common) return;
 
         currentCount = recommendCount;
         currentScoreAdditional = 3 - hintUsed;

--- a/Assets/setsuna/Program/GameScene/Scripts/Stage/SavePoint.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/Stage/SavePoint.cs
@@ -102,7 +102,11 @@ public class SavePoint : SetsunaSlashScript
     }
     void AreaStart()
     {
-        if (isAnotherPart)
+        if (isGoalSave)
+        {
+            player.Status.SetGoaled();
+        }
+        else if (isAnotherPart)
         {
             player.Status.SetAnotherPart();
         }
@@ -162,6 +166,7 @@ public class SavePoint : SetsunaSlashScript
     public void InteractSavePoint(Player pl)
     {
         if (hints.Count <= 0) return;
+        if (pl.Status.IsGoaled) hints.ForEach(h => h.unLocked = true);
         pl.ui.OpenHintUI(hints, pl);
     }
 

--- a/Assets/setsuna/Program/GameScene/Scripts/UI/HintUI.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/UI/HintUI.cs
@@ -112,7 +112,7 @@ public class HintUI : MonoBehaviour
 
     public void Unlock()
     {
-        if (player.Status.UseHint())
+        if (player.Status.TryUseHint())
         {
             displayingHint.unLocked = true;
             Display();

--- a/Assets/setsuna/Program/GameScene/Scripts/UI/slashCountUI/SlashCountUI.cs
+++ b/Assets/setsuna/Program/GameScene/Scripts/UI/slashCountUI/SlashCountUI.cs
@@ -64,13 +64,15 @@ public class SlashCountUI : MonoBehaviour
             slashCells.Add(t.GetComponent<SlashCountCell>());
     }
 
-    public void SetAnotherRoom()
+    public void SetInfinity(bool showJewelCounter)
     {
         infinityGauge.enabled = true;
         isInfinity = true;
         scoreRemains = 3;
         slashRemains = 10;
-        jewelCounter.Show(true);
+
+        if(showJewelCounter)jewelCounter.Show(true);
+
         StartCoroutine(ResetUICoroutine(false));
     }
 


### PR DESCRIPTION
・小部屋、イージーモード、ゴール時、斬撃無限(ダメージも無効)に
・ダメージ用のラッパー関数作成
・ゴール時、ヒントを全開放
・ゴール、小部屋、本編を判断するためのenum作成
・斬撃カウンターの無限化を修正、ジュエルカウンターの表示を選択できるように